### PR TITLE
Fix AVL rotations

### DIFF
--- a/TreeBenchmarks/AVL.h
+++ b/TreeBenchmarks/AVL.h
@@ -26,8 +26,8 @@
  */
 
 #pragma once
-#include "IPerformanceStatsTracker.h"
 #include "BST.h"
+#include <iostream>
 
 // A node in an AVL Tree. Basically, a Binary Tree Node
 // with an additional field for keeping track of the "balance factor"
@@ -49,15 +49,32 @@ public:
 	//		A pointer to the word represented by the key
 	Word* add(std::string key) override;
 
-private:
-	AVLTreeNode* Root = nullptr;
+	void debug_PrintBalanceFactors()
+	{
+		debug_PrintBalanceFactors(static_cast<AVLTreeNode*>(Root));
+	}
 
+private:
 	static void updateBalanceFactors(std::string word, AVLTreeNode*& previous, AVLTreeNode* toInsert);
+
+	void debug_PrintBalanceFactors(AVLTreeNode* n)
+	{
+		if (n == nullptr) return;
+
+		debug_PrintBalanceFactors(static_cast<AVLTreeNode*>(n->Left));
+		std::cout << n->Payload->key << ": " << +n->BalanceFactor << std::endl;
+		debug_PrintBalanceFactors(static_cast<AVLTreeNode*>(n->Right));
+	}
+	
 	void doRotations(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B, char delta);
-	static void rotateLeftLeft(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
-	static void rotateLeftRight(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
-	static void rotateRightRight(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
-	static void rotateRightLeft(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
+	
+	// Perform a left rotation about node n. This pulls up a node from n's right sub tree, pushing
+	// n down one level to the left. Returns the new root of the sub-tree.
+	static AVLTreeNode* rotateLeft(AVLTreeNode* n);
+
+	// Perform a right rotation about node n. This pulls up a node from n's left sub tree, pushing
+	// n down one level to the right. Returns the new root of the sub-tree.
+	static AVLTreeNode* rotateRight(AVLTreeNode* n);
 
 };
 

--- a/TreeBenchmarks/AVL.h
+++ b/TreeBenchmarks/AVL.h
@@ -27,7 +27,7 @@
 
 #pragma once
 #include "IPerformanceStatsTracker.h"
-#include "../BinarySearchTrees/BST.h"
+#include "BST.h"
 
 // A node in an AVL Tree. Basically, a Binary Tree Node
 // with an additional field for keeping track of the "balance factor"
@@ -38,40 +38,26 @@ struct AVLTreeNode : BinaryTreeNode
 	char BalanceFactor = 0;
 };
 
-class AVL : public IPerformanceStatsTracker
+class AVL : public BST
 {
 public:
 	AVL();
 	~AVL();
+
 	// Adds the word to the tree. If the word already exists, its occurrance count is incremeneted
 	// Returns:
 	//		A pointer to the word represented by the key
-	Word* add(std::string key);
+	Word* add(std::string key) override;
 
-	// Finds the word in the tree with the specified tree. 
-	// Returns:
-	//		A pointer to the word represented by the specified key
-	//		A null pointer if the key does not exist in the tree
-	Word* get(std::string key);
-
-	// Prints all words and their occurrance count in alphabetical order to std::cout
-	void inOrderPrint() const { inOrderPrint(Root); }
-
-	// Returns true iff the tree is empty
-	bool isEmpty() const { return Root == nullptr; }
 private:
 	AVLTreeNode* Root = nullptr;
 
 	static void updateBalanceFactors(std::string word, AVLTreeNode*& previous, AVLTreeNode* toInsert);
 	void doRotations(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B, char delta);
 	static void rotateLeftLeft(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
+	static void rotateLeftRight(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
 	static void rotateRightRight(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
+	static void rotateRightLeft(AVLTreeNode* F, AVLTreeNode* A, AVLTreeNode* B);
 
-
-	// Finds a node in the tree with the specified key
-	AVLTreeNode* find(std::string key);
-
-	// Recursively prints the subtree starting from the specified node in order
-	void inOrderPrint(AVLTreeNode* node) const;
 };
 

--- a/TreeBenchmarks/BST.h
+++ b/TreeBenchmarks/BST.h
@@ -93,7 +93,7 @@ public:
 
 	// Returns true iff the tree is empty
 	bool isEmpty() const { return Root == nullptr; }
-private:
+protected:
 	// The node at the root of the tree
 	BinaryTreeNode* Root = nullptr;
 

--- a/TreeBenchmarks/BST.h
+++ b/TreeBenchmarks/BST.h
@@ -29,6 +29,7 @@
 #include "Word.h"
 #include <string>
 #include "IPerformanceStatsTracker.h"
+#include <algorithm>
 
 // A node in a Binary Tree
 struct BinaryTreeNode
@@ -50,6 +51,14 @@ struct BinaryTreeNode
 		if (Left != nullptr) delete Left;
 		if (Right != nullptr) delete Right;
 	}
+
+	// The height of the subtree starting from this node
+	// Returns: One plus the height of the larget subtree (either this node's left or right subtree)
+	size_t Height() const
+	{
+		// TODO: Can we do this? Not sure if we're "allowed" to use std::max in this project
+		return 1 + std::max(Left == nullptr ? 0 : Left->Height(), Right == nullptr ? 0 : Right->Height());
+	}
 };
 
 // A Tree that exhibits the Binary Search Tree Property :
@@ -68,7 +77,7 @@ public:
 	// Adds the word to the tree. If the word already exists, its occurrance count is incremeneted
 	// Returns:
 	//		A pointer to the word represented by the key
-	Word* add(std::string key);
+	virtual Word* add(std::string key);
 
 	// Finds the word in the tree with the specified tree. 
 	// Returns:
@@ -78,6 +87,9 @@ public:
 
 	// Prints all words and their occurrance count in alphabetical order to std::cout
 	void inOrderPrint() const { inOrderPrint(Root); }
+
+	// The height of this tree (0 if empty)
+	size_t height() const { return isEmpty() ? 0 : Root->Height(); }
 
 	// Returns true iff the tree is empty
 	bool isEmpty() const { return Root == nullptr; }

--- a/TreeBenchmarks/IPerformanceStatsTracker.h
+++ b/TreeBenchmarks/IPerformanceStatsTracker.h
@@ -34,6 +34,8 @@
 class IPerformanceStatsTracker
 {
 public:
+	virtual ~IPerformanceStatsTracker(){}
+
 	// Get the total number of comparisons made internally during the
 	// lifetime of this object
 	size_t getComparisonCount() const { return comparisons; }

--- a/TreeBenchmarks/TreeBenchmarks.cpp
+++ b/TreeBenchmarks/TreeBenchmarks.cpp
@@ -9,9 +9,13 @@ int main()
 {
 	AVL tree;
 
-	tree.add("3");
-	tree.add("2");
+	tree.add("4");
 	tree.add("1");
+	tree.add("2");
+	tree.add("3");
+
+
+	tree.debug_PrintBalanceFactors();
 
 	assert(tree.height() == 2);
 

--- a/TreeBenchmarks/TreeBenchmarks.cpp
+++ b/TreeBenchmarks/TreeBenchmarks.cpp
@@ -2,10 +2,19 @@
 //
 
 #include "stdafx.h"
-
+#include "AVL.h"
+#include <cassert>
 
 int main()
 {
+	AVL tree;
+
+	tree.add("3");
+	tree.add("2");
+	tree.add("1");
+
+	assert(tree.height() == 2);
+
     return 0;
 }
 


### PR DESCRIPTION
I don't like the way AVL Rotations are explained in the slides. Based off of this image, it seems we can transform a LR or RL case into an LL or LR case and just makes more sense:

![](https://upload.wikimedia.org/wikipedia/commons/f/f5/AVL_Tree_Rebalancing.svg)

This PR changes the rotation code to use this. I've tested it for each of the four cases when the root is re-balanced in the process, and once for a LR where the main pivot point was past the root. We should probably test some more though (unit tests ftw?)
